### PR TITLE
Add an --exclude cli option to exclude some systemd units from the checks

### DIFF
--- a/bin/pynagsystemd.py
+++ b/bin/pynagsystemd.py
@@ -13,7 +13,13 @@ import nagiosplugin
 
 
 class SystemdStatus(nagiosplugin.Resource):
+    """
+    :param list excludes: A list of systemd unit names.
+    """
     name = 'SYSTEMD'
+
+    def __init__(self, excludes=[]):
+        self.excludes = excludes
 
     def probe(self):
         # Execute systemctl --failed --no-legend and get output
@@ -34,9 +40,10 @@ class SystemdStatus(nagiosplugin.Resource):
                 split_line = line.split()
                 unit = split_line[0]
                 active = split_line[2]
-                yield nagiosplugin.Metric(unit, active, context='systemd')
-        else:
-            yield nagiosplugin.Metric('all', None, context='systemd')
+                if unit not in self.excludes:
+                    yield nagiosplugin.Metric(unit, active, context='systemd')
+
+        yield nagiosplugin.Metric('all', None, context='systemd')
 
 
 class ServiceStatus(nagiosplugin.Resource):
@@ -88,14 +95,18 @@ class SystemdSummary(nagiosplugin.Summary):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-s", "--service", type=str, dest="service", help="Name of the Service that is beeing tested")
+    exclusive_group = parser.add_mutually_exclusive_group()
+    exclusive_group.add_argument('-e', '--exclude', metavar='UNIT', action='append', default=[],
+        help='Exclude a systemd unit from the checks. This option can be applied multiple times. For example: -e mnt-data.mount -e task.service')
+    exclusive_group.add_argument("-s", "--service", type=str, dest="service", help="Name of the Service that is beeing tested")
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Increase output verbosity (use up to 3 times)')
+
 
     args = parser.parse_args()
 
     if args.service is None:
         check = nagiosplugin.Check(
-            SystemdStatus(),
+            SystemdStatus(excludes=args.exclude),
             SystemdContext(),
             SystemdSummary())
     else:


### PR DESCRIPTION
In my opinion your very nice little monitoring plugin lacks the option to exclude some systemd units from
the checks. 

In my setup I use systemd to automount my NAS server. This units are failing regulary when I turn off my NAS server. I don’t want that Nagios / Icinga yells at me, because in turn off my NAS to save some money ;-)

Please merge!